### PR TITLE
Revert version and theme bump from f5f826a

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -112,4 +112,4 @@ enableEmoji = true
 
 [module.hugoVersion]
 extended = true
-min = '0.128.0'
+min = '0.111.3'


### PR DESCRIPTION
Debian Bookworm only supports Hugo v0.111.3, and before the above
commit, everything build OK with that version. Roll back so that works.
